### PR TITLE
toredis to unbload in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 ln -s credstore.py credstore
 ln -s rflat.py rflat 
-ln -s toredis.py toredis
+ln -s unbloat.py unbloat
 chmod +x credstore.py
 chmod +x rflat.py
-chmod +x toredis.py
+chmod +x unbloat.py


### PR DESCRIPTION
Fix `install.sh` to point to the renamed file.